### PR TITLE
Support more HTTP methods for RESTful services

### DIFF
--- a/intlibs/net/net.cpp
+++ b/intlibs/net/net.cpp
@@ -539,6 +539,10 @@ std::string HttpConnection::methodString() {
 		return "GET";
 	case HTTP_POST:
 		return "POST";
+	case HTTP_PUT:
+		return "PUT";
+	case HTTP_DELETE:
+		return "DELETE";
 	case HTTP_HEAD:
 		return "HEAD";
 	default:

--- a/runtimes/cpp/platforms/symbian/src/netImpl.cpp
+++ b/runtimes/cpp/platforms/symbian/src/netImpl.cpp
@@ -752,6 +752,12 @@ void CHttpConnection::FormatRequestL() {
 	case HTTP_POST:
 		APPEND(_L8("POST "));
 		break;
+	case HTTP_PUT:
+		APPEND(_L8("PUT "));
+		break;
+	case HTTP_DELETE:
+		APPEND(_L8("DELETE "));
+		break;
 	case HTTP_HEAD:
 		APPEND(_L8("HEAD "));
 		break;

--- a/runtimes/java/platforms/android/src/SyscallNetwork.jpp
+++ b/runtimes/java/platforms/android/src/SyscallNetwork.jpp
@@ -296,6 +296,12 @@ NETSYSCALL(MAHandle) maHttpCreate(String url, int method) throws Exception
 		case HTTP_POST:
 			httpConn.setRequestMethod("POST");
 			break;
+		case HTTP_PUT:
+			httpConn.setRequestMethod("PUT");
+			break;
+		case HTTP_DELETE:
+			httpConn.setRequestMethod("DELETE");
+			break;
 		case HTTP_HEAD:
 			httpConn.setRequestMethod("HEAD");
 			break;

--- a/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/internal/android/MoSyncNetwork.java
+++ b/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/internal/android/MoSyncNetwork.java
@@ -1112,6 +1112,12 @@ public class MoSyncNetwork
 				case HTTP_POST:
 					httpConnection.setRequestMethod("POST");
 					break;
+				case HTTP_PUT:
+					httpConnection.setRequestMethod("PUT");
+					break;
+				case HTTP_DELETE:
+					httpConnection.setRequestMethod("DELETE");
+					break;
 				case HTTP_HEAD:
 					httpConnection.setRequestMethod("HEAD");
 					break;

--- a/runtimes/java/platforms/javaME/src/networking.jpp
+++ b/runtimes/java/platforms/javaME/src/networking.jpp
@@ -195,6 +195,14 @@ NETSYSCALL(MAHandle) maHttpCreate(String url, int method) throws Exception {
 		rw = Connector.READ_WRITE;
 		methString = HttpConnection.POST;
 		break;
+	case HTTP_PUT:
+		rw = Connector.READ;
+		methString = HttpConnection.PUT;
+		break;
+	case HTTP_DELETE:
+		rw = Connector.READ;
+		methString = HttpConnection.DELETE;
+		break;
 	case HTTP_HEAD:
 		rw = 0;	//uncertain if this works
 		methString = HttpConnection.HEAD;

--- a/tools/idl2/maapi.idl
+++ b/tools/idl2/maapi.idl
@@ -905,6 +905,8 @@ interface MAAPI {
 		GET = 1;
 		POST = 2;
 		HEAD = 3;
+		PUT = 4;
+		DELETE = 5;
 	}
 
 	/**
@@ -918,7 +920,7 @@ interface MAAPI {
 	* begun, you may no longer set request headers.
 
 	* \param url An HTTP or HTTPS URL. See maConnect() for the exact form.
-	* \param method #HTTP_GET, #HTTP_POST or #HTTP_HEAD.
+	* \param method #HTTP_GET, #HTTP_POST, #HTTP_HEAD, #HTTP_PUT or #HTTP_DELETE.
 	* \returns An unfinished HTTP connection handle \>0, or a
 	* \link #CONNERR_GENERIC CONNERR \endlink value.
 	* \see maHttpFinish


### PR DESCRIPTION
Hi,

in order to use many of today's REST APIs, we need support for the DELETE and PUT verbs. Those seem to be missing in the current trunk, so we made this small patch. Unfortunately, we don't have a working build environment for MoSync, so this is more or less untested :) Please have a look at it and decide if it's worth merging with the trunk.
