### PR TITLE
Wormhole sensor manager API: Removed the interval option from startWatch...

### DIFF
--- a/examples/html5/WormholeDemo/LocalFiles/w3csensors.js
+++ b/examples/html5/WormholeDemo/LocalFiles/w3csensors.js
@@ -21,7 +21,7 @@ function toggleAccelW3C()
 {
 	if(accelerometer.status == "open")
 	{
-		accelerometer.startWatch({interval:1000});
+		accelerometer.startWatch();
 	}
 	else
 	{
@@ -57,7 +57,7 @@ function toggleMagFieldW3C()
 {
 	if(magneticField.status == "open")
 	{
-		magneticField.startWatch({interval:1000});
+		magneticField.startWatch();
 	}
 	else
 	{
@@ -91,7 +91,7 @@ function toggleOrientationW3C()
 {
 	if(orientationSensor.status == "open")
 	{
-		orientationSensor.startWatch({interval:1000});
+		orientationSensor.startWatch();
 	}
 	else
 	{
@@ -126,7 +126,7 @@ function toggleGyroscopeW3C()
 {
 	if(gyroscope.status == "open")
 	{
-		gyroscope.startWatch({interval:1000});
+		gyroscope.startWatch();
 	}
 	else
 	{
@@ -160,7 +160,7 @@ function toggleProximityW3C()
 {
 	if(proximity.status == "open")
 	{
-		proximity.startWatch({interval:1000});
+		proximity.startWatch();
 	}
 	else
 	{

--- a/libs/Wormhole/Libs/W3C/SensorManager.cpp
+++ b/libs/Wormhole/Libs/W3C/SensorManager.cpp
@@ -99,7 +99,7 @@ namespace Wormhole
 						mSensorSingleReadFlag[maType] = true;
 					}
 
-					int result = maSensorStart(maType,interval);
+					int result = maSensorStart(maType,SENSOR_RATE_NORMAL);
 					if(result == SENSOR_ERROR_NONE)
 					{
 						//The the message handler to send sensor events to this object

--- a/libs/Wormhole/jslib/mdDocs/sensormanager/mosync-sensormanager.md
+++ b/libs/Wormhole/jslib/mdDocs/sensormanager/mosync-sensormanager.md
@@ -18,7 +18,7 @@ Methods
  * SensorRequest.addEventListener(event, listener)
  * SensorRequest.removeEventListener(event, listener)
 
- * SensorConnection.startWatch(watchOptions)
+ * SensorConnection.startWatch()
  * SensorConnection.endWatch()
  * SensorConnection.read()
  * SensorRequest.addEventListener(event, listener)
@@ -133,14 +133,9 @@ Usage
 			}
 		}
 
-SensorConnection.startWatch(watchOptions)
+SensorConnection.startWatch()
 ==================
 Starts the periodic sampling of the sensor
-	
-Paremeters
--------------
-* __watchOptions__ Struct containing the sampling options
-* __watchOptions.interval__ the sampling period in milliseconds
 
 SensorConnection.endWatch()
 ==========================

--- a/libs/Wormhole/jslib/mosync-sensormanager.js
+++ b/libs/Wormhole/jslib/mosync-sensormanager.js
@@ -172,10 +172,8 @@ function SensorConnection(options)
 
 	/**
 		Starts the periodic sampling of the sensor
-		@param watchOptions Struct containing the sampling options
-		@param watchOptions.interval the sampling period in milliseconds
 	*/
-	this.startWatch = function(watchOptions)
+	this.startWatch = function()
 	{
 		if(self.status != "open")
 		{
@@ -194,7 +192,7 @@ function SensorConnection(options)
 			callbackId,
 			"SensorManager",
 			"startSensor",
-			{"type":"" + self.type, "interval":watchOptions.interval});
+			{"type":"" + self.type, "interval":0});
 	};
 
 	/**


### PR DESCRIPTION
..., always set to SENSOR_RATE_NORMAL. Updated dcumentation and WormholeDemo
