### PR TITLE
MOSYNC-1474: VideoView widget implemented + small changes made to the VideoNativeUIExample

### DIFF
--- a/examples/cpp/VideoNativeUIExample/SettingsScreen.cpp
+++ b/examples/cpp/VideoNativeUIExample/SettingsScreen.cpp
@@ -165,13 +165,13 @@ void SettingsScreen::createMainLayout()
 void SettingsScreen::setDefaultHomepage()
 {
 	// Default urls depending on the platform.
-	if ( isAndroid() )
+	if (isAndroid())
 	{
 		mHomeUrl->setText(HOME_URL_ANDROID);
 	}
 	else
 	{
-		mHomeUrl->setText(HOME_URL_IOS);
+		mHomeUrl->setText(HOME_URL_WINDOWSPHONE);
 	}
 }
 

--- a/examples/cpp/VideoNativeUIExample/Util.h
+++ b/examples/cpp/VideoNativeUIExample/Util.h
@@ -54,11 +54,12 @@ const MAUtil::String SOURCE_ERROR       = "Some error occurred";
 /**
  * Strings for the Settings Screen.
  */
-const MAUtil::String DISPLAY_DURATION 	 = " Display Duration ";
-const MAUtil::String HOME_URL			 = " Home URL ";
-const MAUtil::String HOME_URL_ANDROID 	 = "http://www.mosync.com/files/videos/Video.3gp";
-const MAUtil::String HOME_URL_IOS 		 = "http://www.mosync.com/files/videos/ExVideo.m3u8";
-const MAUtil::String RESET_TO_DEFAULT 	 = "Reload default source";
+const MAUtil::String DISPLAY_DURATION 	   = " Display Duration ";
+const MAUtil::String HOME_URL			   = " Home URL ";
+const MAUtil::String HOME_URL_ANDROID 	   = "http://www.mosync.com/files/videos/Video.3gp";
+const MAUtil::String HOME_URL_IOS 		   = "http://www.mosync.com/files/videos/ExVideo.m3u8";
+const MAUtil::String HOME_URL_WINDOWSPHONE = "http://www.educationalquestions.com/video/ELL_PART_5_768k.wmv";
+const MAUtil::String RESET_TO_DEFAULT 	   = "Reload default source";
 
 void getScreenSize();
 int getScreenWidth();

--- a/examples/cpp/VideoNativeUIExample/VideoScreen.h
+++ b/examples/cpp/VideoNativeUIExample/VideoScreen.h
@@ -160,11 +160,17 @@ private:
 	Button* mPlay;
 	Button* mPause;
 	Button* mStop;
+	Button *mSeek;
 
 	/**
 	 * Label that displays video total duration.
 	 */
 	Label* mDuration;
+
+	/**
+	 * Label that displays debug information
+	 */
+	Label* mDebugInfo;
 
 	/**
 	 *  Edit box for setting the uri or local path.

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncVideoView.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncVideoView.cs
@@ -1,287 +1,337 @@
-﻿///* Copyright (C) 2011 MoSync AB
+﻿/* Copyright (C) 2011 MoSync AB
 
-//This program is free software; you can redistribute it and/or
-//modify it under the terms of the GNU General Public License,
-//version 2, as published by the Free Software Foundation.
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License,
+version 2, as published by the Free Software Foundation.
 
-//This program is distributed in the hope that it will be useful,
-//but WITHOUT ANY WARRANTY; without even the implied warranty of
-//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
 
-//You should have received a copy of the GNU General Public License
-//along with this program; if not, write to the Free Software
-//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-//MA 02110-1301, USA.
-//*/
-///**
-// * @file MoSyncVideoView.cs
-// * @author ovidel
-// *
-// * @brief VideoView Widget implementation for the NativeUI
-// *        component on Windows Phone 7, language C#
-// *
-// * @platform WP 7.1
-// **/
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+*/
+/**
+ * @file MoSyncVideoView.cs
+ * @author ovidel and Spiridon Alexandru
+ *
+ * @brief VideoView Widget implementation for the NativeUI
+ *        component on Windows Phone 7, language C#
+ *
+ * @platform WP 7.1
+ **/
 
-//using System;
-//using System.Net;
-//using System.ComponentModel;
-//using System.Windows;
-//using System.Windows.Controls;
-//using System.Windows.Threading;
-//using System.Windows.Media;
-//using System.Windows.Shapes;
+using System;
+using System.Net;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using System.Windows.Media;
+using System.Windows.Shapes;
 
-//namespace MoSync
-//{
-//    namespace NativeUI
-//    {
+namespace MoSync
+{
+    namespace NativeUI
+    {
 
-//        /**
-//        * VideoView class defines the attributes and behavior of a "video player"
-//        */
-//        public class VideoView : WidgetBaseWindowsPhone
-//        {
-//            private MediaElement mMediaElement;
+        /**
+         * VideoView class defines the attributes and behavior of a "video player" without any default
+         * visual interface.
+         */
+        public class VideoView : WidgetBaseWindowsPhone
+        {
+            private MediaElement mMediaElement;
 
-//            /**
-//             * Constructor
-//             */
-//            public VideoView()
-//            {
-//                mMediaElement = new MediaElement();
+            /**
+             * Constructor
+             */
+            public VideoView()
+            {
+                mMediaElement = new MediaElement();
 
-//                mView = mMediaElement;
+                mView = mMediaElement;
 
-//                /**
-//                 * the delegates that respond to the widget's events
-//                 */
+                /**
+                 * the delegates that respond to the widget's events
+                 */
 
-//                // MAW_VIDEO_VIEW_STATE_FINISHED
-//                mMediaElement.MediaEnded += new RoutedEventHandler(
-//                    delegate(object from, RoutedEventArgs args)
-//                    {
-//                        // post the event to MoSync runtime
-//                        Memory eventData = new Memory(8);
-//                        const int MAWidgetEventData_eventType = 0;
-//                        const int MAWidgetEventData_widgetHandle = 4;
-//                        eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_FINISHED);
-//                        eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
-//                        mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
-//                    }
-//                ); // end of mMediaElement.MediaEnded
+                // MAW_VIDEO_VIEW_STATE_FINISHED
+                // called when the movie has finished the playback
+                mMediaElement.MediaEnded += new RoutedEventHandler(
+                    delegate(object from, RoutedEventArgs args)
+                    {
+                        // post the event to MoSync runtime
+                        Memory eventData = new Memory(12);
+                        // set the main event type: MAW_EVENT_VIDEO_STATE_CHANGED
+                        const int MAWidgetEventData_widgetEventType = 0;
+                        const int MAWidgetEventData_widgetHandle = 4;
+                        // set the banner event type: MAW_VIDEO_VIEW_STATE_FINISHED
+                        const int MAWidgetEventData_eventType = 8;
+                        eventData.WriteInt32(MAWidgetEventData_widgetEventType, MoSync.Constants.MAW_EVENT_VIDEO_STATE_CHANGED);
+                        eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
+                        eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_FINISHED);
+                        mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
+                    }
+                ); // end of mMediaElement.MediaEnded
 
-//                 // MAW_VIDEO_VIEW_STATE_SOURCE_READY
-//                 mMediaElement.MediaOpened += new RoutedEventHandler(
-//                    delegate(object from, RoutedEventArgs args)
-//                    {
-//                        // post the event to MoSync runtime
-//                        Memory eventData = new Memory(8);
-//                        const int MAWidgetEventData_eventType = 0;
-//                        const int MAWidgetEventData_widgetHandle = 4;
-//                        eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_SOURCE_READY);
-//                        eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
-//                        mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
-//                    }
-//                ); // end of mMediaElement.MediaOpened
+                // MAW_VIDEO_VIEW_STATE_SOURCE_READY
+                // called when the media stream has been validated and opened, and the file headers have been read
+                mMediaElement.MediaOpened += new RoutedEventHandler(
+                   delegate(object from, RoutedEventArgs args)
+                   {
+                       Memory eventData = new Memory(12);
+                       // set the main event type: MAW_EVENT_VIDEO_STATE_CHANGED
+                       const int MAWidgetEventData_widgetEventType = 0;
+                       const int MAWidgetEventData_widgetHandle = 4;
+                       // set the banner event type: MAW_VIDEO_VIEW_STATE_SOURCE_READY
+                       const int MAWidgetEventData_eventType = 8;
+                       eventData.WriteInt32(MAWidgetEventData_widgetEventType, MoSync.Constants.MAW_EVENT_VIDEO_STATE_CHANGED);
+                       eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
+                       eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_SOURCE_READY);
+                       mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
+                   }
+               ); // end of mMediaElement.MediaOpened
 
-//                 // MAW_VIDEO_VIEW_STATE_INTERRUPTED
-//                 mMediaElement.MediaFailed += new EventHandler<ExceptionRoutedEventArgs>(
-//                    delegate(object from, ExceptionRoutedEventArgs args)
-//                    {
-//                        // post the event to MoSync runtime
-//                        Memory eventData = new Memory(8);
-//                        const int MAWidgetEventData_eventType = 0;
-//                        const int MAWidgetEventData_widgetHandle = 4;
-//                        eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_INTERRUPTED);
-//                        eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
-//                        mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
-//                    }
-//                ); // end of mMediaElement.MediaFailed
-//            }
+                // MAW_VIDEO_VIEW_STATE_INTERRUPTED
+                // called when there is an error associated with the media source.
+                mMediaElement.MediaFailed += new EventHandler<ExceptionRoutedEventArgs>(
+                   delegate(object from, ExceptionRoutedEventArgs args)
+                   {
+                       // post the event to MoSync runtime
+                       Memory eventData = new Memory(12);
+                       // set the main event type: MAW_EVENT_VIDEO_STATE_CHANGED
+                       const int MAWidgetEventData_widgetEventType = 0;
+                       const int MAWidgetEventData_widgetHandle = 4;
+                       // set the banner event type: MAW_VIDEO_VIEW_STATE_INTERRUPTED
+                       const int MAWidgetEventData_eventType = 8;
+                       eventData.WriteInt32(MAWidgetEventData_widgetEventType, MoSync.Constants.MAW_EVENT_VIDEO_STATE_CHANGED);
+                       eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
+                       eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_INTERRUPTED);
+                       mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
+                   }
+               ); // end of mMediaElement.MediaFailed
+            }
 
+            /**
+             * Property for setting the path to a local video file.
+             * set: a String containing the path to the video file.
+             */
+            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_PATH)]
+            public String Path
+            {
+                set
+                {
+                    Uri mediaUri;
+                    // we try to create the uri from the string passed to the setter
+                    if (Uri.TryCreate(value, UriKind.Relative, out mediaUri))
+                    {
+                        mMediaElement.Source = mediaUri;
+                    }
+                }
+            }
 
-//            /**
-//             * Property for setting the url to a video file.
-//             * set: a String containing the url to the video file.
-//             */
-//            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_URL)]
-//            public String url
-//            {
-//                set
-//                {
-//                    setURI(value);
-//                }
-//            }
+            /**
+             * Property for setting the url to a video file.
+             * set: a String containing the url to the video file.
+             */
+            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_URL)]
+            public String Url
+            {
+                set
+                {
+                    Uri mediaUri;
+                    // we try to create the uri from the string passed to the setter
+                    if (Uri.TryCreate(value, UriKind.Absolute, out mediaUri))
+                    {
+                        mMediaElement.Source = mediaUri;
+                    }
+                }
+            }
 
-
-//            /**
-//             * Property for setting the path to a local video file.
-//             * set: a String containing the path to the video file.
-//             */
-//            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_PATH)]
-//            public String path
-//            {
-//                set
-//                {
-//                    setURI(value);
-//                }
-//            }
-
-
-
-//            /**
-//             * Property for controlling the playback of a video file.
-//             * set: an int describing the action to be taken.
-//             */
-//            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_ACTION)]
-//            public int action
-//            {
-//                set
-//                {
-//                    switch (value)
-//                    {
-//                        case MoSync.Constants.MAW_VIDEO_VIEW_ACTION_PLAY:
-//                            playVideo();
-//                            break;
-//                        case MoSync.Constants.MAW_VIDEO_VIEW_ACTION_STOP:
-//                            stopVideo();
-//                            break;
-//                        case MoSync.Constants.MAW_VIDEO_VIEW_ACTION_PAUSE:
-//                            pauseVideo();
-//                            break;
-//                    }
-//                }
-//            }
-
-
-//            /**
-//             * Property for moving the playing head.
-//             * set: an int representing the milliseconds from the beggining of the video.
-//             */
-//            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_SEEK_TO)]
-//            public int seekTo
-//            {
-//                set
-//                {
-//                    // go to desired position
-//                }
-//            }
-
-
-//            /**
-//             * Property for getting the duration of the current video
-//             * get: an int representing video's duration in seconds
-//             */
-//            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_DURATION)]
-//            public int duration
-//            {
-//                get
-//                {
-//                    int myDuration = 0;
-//                    if (null != mMediaElement.Source)
-//                    {
-//                        // get duration
-//                    }
-
-//                    return myDuration;
-//                }
-//            }
+            /**
+             * Property for controlling the playback of a video file.
+             * set: an int describing the action to be taken.
+             */
+            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_ACTION)]
+            public int Action
+            {
+                set
+                {
+                    switch (value)
+                    {
+                        case MoSync.Constants.MAW_VIDEO_VIEW_ACTION_PLAY:
+                            playVideo();
+                            break;
+                        case MoSync.Constants.MAW_VIDEO_VIEW_ACTION_STOP:
+                            stopVideo();
+                            break;
+                        case MoSync.Constants.MAW_VIDEO_VIEW_ACTION_PAUSE:
+                            pauseVideo();
+                            break;
+                    }
+                }
+            }
 
 
-//            /**
-//             * Property for setting the action type to be appliede .
-//             * set: a String containing the path to the video file.
-//             */
-//            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_PATH)]
-//            public String Path
-//            {
-//                set
-//                {
-//                    setURI(value);
-//                }
-//            }
+            /**
+             * Property for moving the playing head.
+             * set: an int representing the milliseconds from the beginning of the video.
+             */
+            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_SEEK_TO)]
+            public int SeekTo
+            {
+                set
+                {
+                    // go to desired position if seeking is possible and if
+                    // the current position to be set is valid (is not greater than the duration of the media)
+                    if (mMediaElement.CanSeek && value < mMediaElement.NaturalDuration.TimeSpan.TotalMilliseconds)
+                    {
+                        mMediaElement.Position = TimeSpan.FromMilliseconds(value);
+                    }
+                }
+            }
 
+            /**
+             * Property for getting the duration of the current video
+             * get: an int representing video's duration in milliseconds
+             */
+            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_DURATION)]
+            public int Duration
+            {
+                get
+                {
+                    int myDuration = 0;
+                    if (null != mMediaElement.Source)
+                    {
+                        // get duration and then transform it into milliseconds
+                        Duration currentMediaDuration = mMediaElement.NaturalDuration;
+                        myDuration = (int)currentMediaDuration.TimeSpan.TotalMilliseconds;
+                    }
 
-//            // helper method for setting the video's URI
-//            private void setURI(String myURI)
-//            {
-//                // set video here
-//            }
+                    return myDuration;
+                }
+            }
 
-//            // play the video and MAW_VIDEO_VIEW_STATE_PLAYING
-//            private void playVideo()
-//            {
-//                // play it
-//                mMediaElement.Play();
+            /**
+             * Property for getting the buffer percentage of the current video
+             * get: an int representing video's buffered percentage
+             */
+            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_BUFFER_PERCENTAGE)]
+            public int BufferPercentage
+            {
+                get
+                {
+                    // the BufferingProgress returns a double value from the interval [0,1]
+                    // by multiplying this value with 100 we get the buffered percentage
+                    int bufferPercentage = (int)(mMediaElement.BufferingProgress * 100);
+                    return bufferPercentage;
+                }
+            }
 
-//                // post the playing event
-//                Memory eventData = new Memory(8);
-//                const int MAWidgetEventData_eventType = 0;
-//                const int MAWidgetEventData_widgetHandle = 4;
-//                eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_PLAYING);
-//                eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
-//                mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
-//            }
+            /**
+             * Property for getting the current position in time of the current video
+             * get: an int representing video's current position in time (measured in seconds)
+             */
+            [MoSyncWidgetProperty(MoSync.Constants.MAW_VIDEO_VIEW_CURRENT_POSITION)]
+            public int CurrentPosition
+            {
+                get
+                {
+                    // get the current position in seconds
+                    int seconds = (int)mMediaElement.Position.TotalSeconds;
+                    return seconds;
+                }
+            }
 
-//            // pause the video and MAW_VIDEO_VIEW_STATE_PAUSED
-//            private void pauseVideo()
-//            {
-//                // tea break
-//                mMediaElement.Pause();
+            // play the video and MAW_VIDEO_VIEW_STATE_PLAYING
+            private void playVideo()
+            {
+                // play it
+                mMediaElement.Play();
 
-//                // announce the event
-//                Memory eventData = new Memory(8);
-//                const int MAWidgetEventData_eventType = 0;
-//                const int MAWidgetEventData_widgetHandle = 4;
-//                eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_PAUSED);
-//                eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
-//                mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
-//            }
+                // post the event to MoSync runtime
+                Memory eventData = new Memory(12);
+                // set the main event type: MAW_EVENT_VIDEO_STATE_CHANGED
+                const int MAWidgetEventData_widgetEventType = 0;
+                const int MAWidgetEventData_widgetHandle = 4;
+                // set the banner event type: MAW_VIDEO_VIEW_STATE_PLAYING
+                const int MAWidgetEventData_eventType = 8;
+                eventData.WriteInt32(MAWidgetEventData_widgetEventType, MoSync.Constants.MAW_EVENT_VIDEO_STATE_CHANGED);
+                eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
+                eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_PLAYING);
+                mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
+            }
 
-//            // stop the video and MAW_VIDEO_VIEW_STATE_STOPPED
-//            private void stopVideo()
-//            {
-//                // stop it
-//                mMediaElement.Stop();
+            // pause the video and MAW_VIDEO_VIEW_STATE_PAUSED
+            private void pauseVideo()
+            {
+                if (mMediaElement.CanPause)
+                {
+                    // tea break
+                    mMediaElement.Pause();
 
-//                // announce the event
-//                Memory eventData = new Memory(8);
-//                const int MAWidgetEventData_eventType = 0;
-//                const int MAWidgetEventData_widgetHandle = 4;
-//                eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_STOPPED);
-//                eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
-//                mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
-//            }
+                    // post the event to MoSync runtime
+                    Memory eventData = new Memory(12);
+                    // set the main event type: MAW_EVENT_VIDEO_STATE_CHANGED
+                    const int MAWidgetEventData_widgetEventType = 0;
+                    const int MAWidgetEventData_widgetHandle = 4;
+                    // set the banner event type: MAW_VIDEO_VIEW_STATE_PAUSED
+                    const int MAWidgetEventData_eventType = 8;
+                    eventData.WriteInt32(MAWidgetEventData_widgetEventType, MoSync.Constants.MAW_EVENT_VIDEO_STATE_CHANGED);
+                    eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
+                    eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_PAUSED);
+                    mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
+                }
+            }
 
-//            private Uri _SelectedVideoProperty;
-//            public Uri SelectedVideoProperty
-//            {
-//                get
-//                {
-//                    return this._SelectedVideoProperty;
-//                }
-//                set
-//                {
-//                    this._SelectedVideoProperty = value;
-//                    this.NotifyPropertyChanged("SelectedVideoProperty");
-//                }
-//            }
+            // stop the video and MAW_VIDEO_VIEW_STATE_STOPPED
+            private void stopVideo()
+            {
+                // stop it
+                mMediaElement.Stop();
 
+                // post the event to MoSync runtime
+                Memory eventData = new Memory(12);
+                // set the main event type: MAW_EVENT_VIDEO_STATE_CHANGED
+                const int MAWidgetEventData_widgetEventType = 0;
+                const int MAWidgetEventData_widgetHandle = 4;
+                // set the banner event type: MAW_VIDEO_VIEW_STATE_STOPPED
+                const int MAWidgetEventData_eventType = 8;
+                eventData.WriteInt32(MAWidgetEventData_widgetEventType, MoSync.Constants.MAW_EVENT_VIDEO_STATE_CHANGED);
+                eventData.WriteInt32(MAWidgetEventData_widgetHandle, mHandle);
+                eventData.WriteInt32(MAWidgetEventData_eventType, MoSync.Constants.MAW_VIDEO_VIEW_STATE_STOPPED);
+                mRuntime.PostCustomEvent(MoSync.Constants.EVENT_TYPE_WIDGET, eventData);
+            }
 
-//            // Utility
+            private Uri _SelectedVideoProperty;
+            public Uri SelectedVideoProperty
+            {
+                get
+                {
+                    return this._SelectedVideoProperty;
+                }
+                set
+                {
+                    this._SelectedVideoProperty = value;
+                    this.NotifyPropertyChanged("SelectedVideoProperty");
+                }
+            }
 
-//            public event PropertyChangedEventHandler PropertyChanged;
+            // Utility
+            public event PropertyChangedEventHandler PropertyChanged;
 
-//            private void NotifyPropertyChanged(String info)
-//            {
-//                if (PropertyChanged != null)
-//                {
-//                    PropertyChanged(this, new PropertyChangedEventArgs(info));
-//                }
-//            }
+            private void NotifyPropertyChanged(String info)
+            {
+                if (PropertyChanged != null)
+                {
+                    PropertyChanged(this, new PropertyChangedEventArgs(info));
+                }
+            }
 
-//        } // end of class VideoView
-//    } // end of namespace NativeUI
-//} // end of namespace MoSync
+        } // end of class VideoView
+    } // end of namespace NativeUI
+} // end of namespace MoSync

--- a/tools/idl2/maapi.idl
+++ b/tools/idl2/maapi.idl
@@ -7019,7 +7019,7 @@ group WidgetAPI "Widget API" {
 	constset MAString MAW_VIDEO_VIEW_ {
 		/**
 		* @brief Sets the video path.
-		* Note: available only for Android.
+		* Note: available on Android and Windows Phone.
 		* @validvalue Any valid path.
 		*
 		* @setonly
@@ -7081,7 +7081,7 @@ group WidgetAPI "Widget API" {
 		*
 		* NOTE: On Android this value can be retrieved after MAW_VIDEO_VIEW_STATE_SOURCE_READY is received.
 		*       On iOS this value can be retrieved after MAW_VIDEO_STATE_PLAYING is received.
-		* @validvalue An int.
+		* @validvalue An integer representing the total media duration in milliseconds.
 		*
 		* @getonly
 		*
@@ -7113,7 +7113,7 @@ group WidgetAPI "Widget API" {
 		/**
 		* @brief Gets the current position in the video file.
 		*
-		* @validvalue An int.
+		* @validvalue An integer representing the current media position in seconds.
 		*
 		* @getonly
 		*


### PR DESCRIPTION
Video view native UI widget implemented for wp 7.1 + VideoNativeUIExample modified: added a debug label, a seek button - that seeks to the middle of the video - and a new URL (for testing the windows phone version).
