### PR TITLE
Fix for MOSYNC-229

### DIFF
--- a/examples/cpp/HelloNativeUI/MainScreen.cpp
+++ b/examples/cpp/HelloNativeUI/MainScreen.cpp
@@ -143,6 +143,9 @@ MA 02110-1301, USA.
     void MainScreen::editBoxReturn(EditBox* editBox)
     {
 		submitEditBoxContent();
+
+		// Hide the keyboard.
+		mPasswordBox->hideKeyboard();
     }
 
 	/**

--- a/examples/cpp/WikiSearchNativeUI/HomeScreen.cpp
+++ b/examples/cpp/WikiSearchNativeUI/HomeScreen.cpp
@@ -474,6 +474,14 @@ void HomeScreen::customEvent(const MAEvent& event)
 		// Set the current value of the slider.
 		mSliderValue = widgetEventData->sliderValue;
 	}
+	else if(widgetEventData->eventType == MAW_EVENT_EDIT_BOX_RETURN)
+	{
+		// Hide the keyboard.
+		maWidgetSetProperty(
+			widgetEventData->widgetHandle,
+			MAW_EDIT_BOX_SHOW_KEYBOARD,
+			"false");
+	}
 	return;
 }
 

--- a/testPrograms/native_ui_lib/ProgressBar/MainScreen.cpp
+++ b/testPrograms/native_ui_lib/ProgressBar/MainScreen.cpp
@@ -48,6 +48,7 @@ MainScreen::MainScreen() :
 	mSetProgressValueButton->addButtonListener(this);
 	mSetMaximumValueButton->addButtonListener(this);
 	mIncreaseValueButton->addButtonListener(this);
+	mEditBox->addEditBoxListener(this);
 }
 
 /**
@@ -58,6 +59,7 @@ MainScreen::~MainScreen()
     mSetProgressValueButton->removeButtonListener(this);
     mIncreaseValueButton->removeButtonListener(this);
     mSetMaximumValueButton->removeButtonListener(this);
+    mEditBox->removeEditBoxListener(this);
 }
 
 /**
@@ -143,4 +145,15 @@ void MainScreen::createMainLayout() {
 	mIncreaseValueButton = new Button();
 	mIncreaseValueButton->setText("increase value with 10");
 	mMainLayout->addChild(mIncreaseValueButton);
+}
+
+/**
+ * This method is called when the return button was pressed.
+ * On iphone platform the virtual keyboard is not hidden after
+ * receiving this event.
+ * @param editBox The edit box object that generated the event.
+ */
+void MainScreen::editBoxReturn(EditBox* editBox)
+{
+	editBox->hideKeyboard();
 }

--- a/testPrograms/native_ui_lib/ProgressBar/MainScreen.h
+++ b/testPrograms/native_ui_lib/ProgressBar/MainScreen.h
@@ -37,7 +37,8 @@ using namespace NativeUI;
  */
 class MainScreen:
 	public Screen,
-	public ButtonListener
+	public ButtonListener,
+	public EditBoxListener
 {
 
 public:
@@ -80,6 +81,14 @@ private:
 	 * Creates and adds main layout to the screen.
 	 */
 	void createMainLayout();
+
+    /**
+     * This method is called when the return button was pressed.
+     * On iphone platform the virtual keyboard is not hidden after
+     * receiving this event.
+     * @param editBox The edit box object that generated the event.
+     */
+    virtual void editBoxReturn(EditBox* editBox);
 
 private:
 	/**

--- a/testPrograms/native_ui_lib/VideoViewTest/MainScreen.cpp
+++ b/testPrograms/native_ui_lib/VideoViewTest/MainScreen.cpp
@@ -66,6 +66,7 @@ MainScreen::MainScreen() :
 	mVideoControl->addButtonListener(this);
 
 	mVideoView->addVideoViewListener(this);
+	mEditBox->addEditBoxListener(this);
 }
 
 /**
@@ -83,6 +84,7 @@ MainScreen::~MainScreen()
     mVideoControl->removeButtonListener(this);
 
     mVideoView->removeVideoViewListener(this);
+    mEditBox->removeEditBoxListener(this);
 }
 
 /**
@@ -284,4 +286,15 @@ void MainScreen::handleVideoControlButtonClicked()
 	bool value = mVideoView->isControlVisible();
 	printf("MainScreen::handleVideoControlButtonClicked - control visible = %d",
 		value);
+}
+
+/**
+ * This method is called when the return button was pressed.
+ * On iphone platform the virtual keyboard is not hidden after
+ * receiving this event.
+ * @param editBox The edit box object that generated the event.
+ */
+void MainScreen::editBoxReturn(EditBox* editBox)
+{
+	editBox->hideKeyboard();
 }

--- a/testPrograms/native_ui_lib/VideoViewTest/MainScreen.h
+++ b/testPrograms/native_ui_lib/VideoViewTest/MainScreen.h
@@ -35,7 +35,8 @@ using namespace NativeUI;
 class MainScreen:
 	public Screen,
 	public ButtonListener,
-	public VideoViewListener
+	public VideoViewListener,
+	public EditBoxListener
 {
 
 public:
@@ -105,6 +106,14 @@ private:
 	 * Show/hide the video control and change button's text.
 	 */
 	void handleVideoControlButtonClicked();
+
+    /**
+     * This method is called when the return button was pressed.
+     * On iphone platform the virtual keyboard is not hidden after
+     * receiving this event.
+     * @param editBox The edit box object that generated the event.
+     */
+    virtual void editBoxReturn(EditBox* editBox);
 
 private:
 	/**


### PR DESCRIPTION
Fix for MOSYNC-229 "Clicking return does not hide the virtual keyboard on ios for several examples".
