### PR TITLE
pipe-tool: added command line parameter -resnames to generate string name to resource id mappings in MAHeaders.cpp

### DIFF
--- a/tools/pipe-tool/compile.h
+++ b/tools/pipe-tool/compile.h
@@ -802,6 +802,8 @@ decset(FILE *DependFile, NULL)
 dec(FILE *InFile)
 dec(FILE *CodeFile)
 dec(FILE *HeaderFile)
+decset(int Do_WriteResNames, 0)
+dec(FILE *ResNamesFile)
 
 dec(short DEBUG)
 dec(short LIST)

--- a/tools/pipe-tool/rescomp.c
+++ b/tools/pipe-tool/rescomp.c
@@ -358,9 +358,12 @@ short ResourceCommands()
 
 		infoprintf("%d: index = %d ('%s')\n",IndexCount, IndexOffset, Name);
 
-		if (Pass == 2)
-			if (Name[0])
-				fprintf(HeaderFile,"#define idx_%s %d\n", Name, IndexCount);
+		if( Pass == 2 && Name[0] )
+        {
+			fprintf(HeaderFile,"#define idx_%s %d\n", Name, IndexCount);
+            if( Do_WriteResNames )
+                fprintf(ResNamesFile,"    if( strcmp( resName, \"idx_%s\" ) == 0 ) return idx_%s;\n", Name, Name);
+        }
 
 		IndexCount++;
 		return 1;
@@ -1520,8 +1523,11 @@ void FinalizeResource()
 	if (Pass == 2)
 	{
 		if (ResName[0])
+        {
 			fprintf(HeaderFile,"#define %s %d\n", ResName, CurrentResource);
-		else
+            if( Do_WriteResNames )
+                fprintf(ResNamesFile,"    if( strcmp( resourceName, \"%s\" ) == 0 ) return %s;\n", ResName, ResName);
+        } else
 			fprintf(HeaderFile,"//not defined %d\n", CurrentResource);
 	}
 


### PR DESCRIPTION
pipe-tool: added command line parameter -resnames, which generates file MAHeaders.cpp with string name to resource mappings.
Useful if you need to get resource ID (MAHandle) from string resource name at runtime.

Forum topic:
http://www.mosync.com/content/request-resource-name-resource-id-runtime
