### PR TITLE
MOSYNC-2105: solved

### DIFF
--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncNativeUIWindowsPhone.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncNativeUIWindowsPhone.cs
@@ -265,7 +265,7 @@ namespace MoSync
                     if (objType.GetProperty("IsEnabled") != null)
                     {
                         var property = objType.GetProperty("IsEnabled");
-                        return (string)(property.GetValue(mView, null));
+                        return (property.GetValue(mView, null)).ToString();
                     }
                     return null;
                 }


### PR DESCRIPTION
On the windows phone platform, the 'isEnabled()' call lead to an application crash - this is now solved.
