### PR TITLE
Fix for MOSYNC-2107 

### DIFF
--- a/libs/MAUI/WidgetSkin.cpp
+++ b/libs/MAUI/WidgetSkin.cpp
@@ -33,6 +33,8 @@ namespace MAUI {
 		endX(32),
 		startY(16),
 		endY(32),
+		imageWidth(endX),
+		imageHeight(endY),
 		selectedTransparent(true),
 		unselectedTransparent(true)
 		{


### PR DESCRIPTION
Calling the empty WidgetSkin constructor gives panic.
