### PR TITLE
MOSYNC-2245: the camera captured image is now rotated depending on the s...

### DIFF
--- a/testPrograms/orientationNativeUI/TestOrientationForNativeUI/SecondScreen.cpp
+++ b/testPrograms/orientationNativeUI/TestOrientationForNativeUI/SecondScreen.cpp
@@ -57,6 +57,7 @@ namespace OrientationTest
 		mLabel->setWidth(LABEL_WIDTH);
 		mLabel->setHeight(LABEL_HEIGHT);
 		mLabel->setBackgroundColor(LABEL_BG_COLOR);
+		mLabel->setText("test");
 		mMainLayout->addChild(mLabel);
 
 		MAUtil::Environment::getEnvironment().addPointerListener(this);


### PR DESCRIPTION
commit de2dd6718603120e10d8b6c7f09a4a160cbcf61f
Author: Spiridon Alexandru spiridon.g.alex@gmail.com
Date:   Thu Jun 28 17:03:46 2012 +0300

```
MOSYNC-2245: the camera captured image is now rotated depending on the screen orientation because the 'Orientation' member of the PhotoCamera which should represent the angle of rotation is always 90 degrees (I couldn't find a scenario where this value is different); + added a text to the TestOrientationForNativeUI label because on Windows Phone, the label background color cannot be changed so the widget was not visible
```
