### PR TITLE
Fix for MOSYNC-2251 invalid receipt in purchase example.

### DIFF
--- a/examples/cpp/PurchaseExample/ApplicationController.cpp
+++ b/examples/cpp/PurchaseExample/ApplicationController.cpp
@@ -139,6 +139,18 @@ void ApplicationController::requestFailed(const Purchase& purchase,
 {
 	mMainScreen->productError("Purchase failed for product "
 			+ purchase.getProductId() );
+	for (int i = 0; i < mPurchases.size(); i++)
+	{
+		Purchase* purchaseObj = mPurchases[i];
+		if (purchase.getHandle() == purchaseObj->getHandle())
+		{
+			mPurchases.remove(i);
+			delete purchaseObj;
+			purchaseObj = NULL;
+			break;
+		}
+	}
+
 }
 
 /**

--- a/runtimes/cpp/platforms/iphone/Classes/MoSyncMain.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/MoSyncMain.mm
@@ -204,19 +204,19 @@ void MoSync_ShowMessageBox(const char *title, const char *msg, bool kill) {
 void MoSync_ShowAlert(const char* title, const char* message, const char* button1, const char* button2, const char* button3)
 {
 	NSString* nsTitle = nil;
-	if(title != nil)
+	if(title != nil && (strlen(title) != 0))
 		nsTitle = [[NSString alloc] initWithBytes:title length:strlen(title) encoding:NSUTF8StringEncoding];
 
 	NSString* nsButton1 = nil;
-	if(button1 != nil)
+	if(button1 != nil && (strlen(button1) != 0))
 		nsButton1 = [[NSString alloc] initWithBytes:button1 length:strlen(button1) encoding:NSUTF8StringEncoding];
 
 	NSString* nsButton2 = nil;
-	if(button2 != nil)
+	if(button2 != nil && (strlen(button2) != 0))
 		nsButton2 = [[NSString alloc] initWithBytes:button2 length:strlen(button2) encoding:NSUTF8StringEncoding];
 
 	NSString* nsButton3 = nil;
-	if(button3 != nil)
+	if(button3 != nil && (strlen(button3) != 0))
 		nsButton3 = [[NSString alloc] initWithBytes:button3 length:strlen(button3) encoding:NSUTF8StringEncoding];
 
 	[sMoSyncView showAlert:[[NSString alloc] initWithBytes:message length:strlen(message) encoding:NSUTF8StringEncoding]

--- a/runtimes/cpp/platforms/iphone/Classes/purchase/PurchaseManager.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/purchase/PurchaseManager.mm
@@ -495,7 +495,8 @@ static PurchaseManager *sharedInstance = nil;
         {
             continue;
         }
-        if ([payment isEqual:productPayment])
+        if ([payment isEqual:productPayment] &&
+            !product.isPurchased)
         {
             return product;
         }

--- a/runtimes/cpp/platforms/iphone/Classes/purchase/PurchaseProduct.h
+++ b/runtimes/cpp/platforms/iphone/Classes/purchase/PurchaseProduct.h
@@ -86,6 +86,11 @@
      * Validation response received from Apple App Store.
      */
     NSDictionary* _validationResponse;
+
+    /**
+     * Flag to indicate if the product is purchased.
+     */
+    BOOL _isPurchased;
 }
 
 /**
@@ -151,5 +156,6 @@
             bufferSize:(const int) bufferSize;
 
 @property(nonatomic, readonly) MAHandle handle;
+@property(nonatomic, readonly) BOOL isPurchased;
 
 @end

--- a/runtimes/cpp/platforms/iphone/Classes/purchase/PurchaseProduct.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/purchase/PurchaseProduct.mm
@@ -112,6 +112,7 @@ NSString* const kReceiptDateMsKey = @"original_purchase_date_ms";
 @implementation PurchaseProduct
 
 @synthesize handle = _handle;
+@synthesize isPurchased = _isPurchased;
 
 /**
  * Create a product product using a handle and an id.
@@ -129,6 +130,7 @@ NSString* const kReceiptDateMsKey = @"original_purchase_date_ms";
         _restoredPayment = nil;
         _handle = productHandle;
         _productID = [productID retain];
+        _isPurchased = NO;
         NSSet* productSet = [NSSet setWithObject:_productID];
         _productRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:productSet];
         _productRequest.delegate = self;
@@ -158,7 +160,7 @@ NSString* const kReceiptDateMsKey = @"original_purchase_date_ms";
         _productID = [_restoredPayment.productIdentifier retain];
         _transaction = [transaction retain];
         _product = nil;
-
+        _isPurchased = YES;
         [self createParserComponents];
     }
 
@@ -458,6 +460,7 @@ NSString* const kReceiptDateMsKey = @"original_purchase_date_ms";
 -(void) handleTransactionStatePurchased:(SKPaymentTransaction*) transaction
 {
     _transaction = [transaction retain];
+    _isPurchased = YES;
     [self sendPurchaseEvent:MA_PURCHASE_EVENT_REQUEST
                       state:MA_PURCHASE_STATE_COMPLETED
                   errorCode:0];


### PR DESCRIPTION
Fixed a bug with maAlert() on iOS.
