### PR TITLE
Camera module updated + MOSYNC-2296: solved + MOSYNC-2292: solved

### DIFF
--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/MoSyncRuntime.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/MoSyncRuntime.cs
@@ -186,6 +186,9 @@ namespace MoSync
 			mIoctls = new Ioctls();
 			mIoctlInvoker = new IoctlInvoker(mCore, mIoctls);
 
+            mCurrentResourceHandle = 1;
+            mStaticResourceCount = 0;
+
 			PhoneApplicationFrame mainPage = (PhoneApplicationFrame)Application.Current.RootVisual;
 
 			mainPage.MouseLeftButtonDown += MouseLeftButtonDown;

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncAdsModule.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncAdsModule.cs
@@ -370,15 +370,27 @@ namespace MoSync
                 switch (property)
                 {
                     case MoSync.Constants.MA_ADS_HEIGHT:
+                        stringvalue = "";
+                        MoSync.Util.RunActionOnMainThreadSync(() =>
+                            {
+                                stringvalue = ((int)mAd.Height).ToString();
+                            }
+                        );
                         core.GetDataMemory().WriteStringAtAddress(
                             _value,
-                            mAd.Height.ToString(),
+                            stringvalue,
                             _bufSize);
                         break;
                     case MoSync.Constants.MA_ADS_WIDTH:
+                        stringvalue = "";
+                        MoSync.Util.RunActionOnMainThreadSync(() =>
+                            {
+                                stringvalue = ((int)mAd.Width).ToString();
+                            }
+                        );
                         core.GetDataMemory().WriteStringAtAddress(
                             _value,
-                            mAd.Width.ToString(),
+                            stringvalue,
                             _bufSize);
                         break;
                     case MoSync.Constants.MA_ADS_VISIBLE:
@@ -406,21 +418,39 @@ namespace MoSync
                             _bufSize);
                         break;
                     case MoSync.Constants.MA_ADS_COLOR_BG:
+                        stringvalue = "";
+                        MoSync.Util.RunActionOnMainThreadSync(() =>
+                            {
+                                stringvalue = mAd.BackgroundColor.ToString();
+                            }
+                        );
                         core.GetDataMemory().WriteStringAtAddress(
                             _value,
-                            mAd.BackgroundColor,
+                            stringvalue,
                             _bufSize);
                         break;
                     case MoSync.Constants.MA_ADS_COLOR_BORDER:
+                        stringvalue = "";
+                        MoSync.Util.RunActionOnMainThreadSync(() =>
+                            {
+                                stringvalue = mAd.BorderColor.ToString();
+                            }
+                        );
                         core.GetDataMemory().WriteStringAtAddress(
                             _value,
-                            mAd.BorderColor,
+                            stringvalue,
                             _bufSize);
                         break;
                     case MoSync.Constants.MA_ADS_COLOR_TEXT:
+                        stringvalue = "";
+                        MoSync.Util.RunActionOnMainThreadSync(() =>
+                            {
+                                stringvalue = mAd.TextColor.ToString();
+                            }
+                        );
                         core.GetDataMemory().WriteStringAtAddress(
                             _value,
-                            mAd.TextColor,
+                            stringvalue,
                             _bufSize);
                         break;
                     default:

--- a/testPrograms/AdsTest/.mosyncproject
+++ b/testPrograms/AdsTest/.mosyncproject
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project supports-build-configs="true" version="1.2">
+<project supports-build-configs="true" version="1.4">
 <build.cfg id="Debug" types="Debug"/>
 <build.cfg id="Release" types="Release"/>
+<criteria>
+<filter type="com.mobilesorcery.sdk.capabilities.devices.elementfactory">
+<capabilities optional="" required="File\ Storage Internet\ Access"/>
+</filter>
+</criteria>
 <properties>
 <property key="build.prefs:additional.include.paths/Release" value=""/>
 <property key="build.prefs:additional.libraries" value="MAUtil.lib"/>
 <property key="build.prefs:additional.libraries/Debug" value="MAUtilD.lib"/>
 <property key="build.prefs:additional.libraries/Release" value="MAUtil.lib, NativeUI.lib, Ads.lib"/>
 <property key="build.prefs:additional.library.paths/Release" value=""/>
+<property key="build.prefs:app.permissions" value="File\ Storage Internet\ Access Vibration"/>
 <property key="build.prefs:extra.link.sw/Release" value=""/>
 <property key="build.prefs:extra.res.sw/Release" value=""/>
+<property key="build.prefs:gcc.switches/Release" value="-O2"/>
 <property key="build.prefs:gcc.warnings/Release" value="0"/>
 <property key="build.prefs:memory.data/Release" value="4000"/>
 <property key="build.prefs:memory.heap/Release" value="1024"/>
@@ -17,6 +24,8 @@
 <property key="build.prefs:project.type" value=""/>
 <property key="dependency.strategy" value="0"/>
 <property key="excludes/Release" value=""/>
+<property key="profile.mgr.type" value="0"/>
 <property key="template.id" value="project.nativeui"/>
+<property key="winmobilecs:guid" value="7f4ab180-bd1e-102f-804f-b5d4e3de774b"/>
 </properties>
 </project>

--- a/testPrograms/AdsTest/MainScreen.cpp
+++ b/testPrograms/AdsTest/MainScreen.cpp
@@ -101,7 +101,21 @@ void MainScreen::createMainLayout() {
 	// Create and add the main layout to the screen.
 	VerticalLayout* mainLayout = new VerticalLayout();
 	Screen::setMainWidget(mainLayout);
-	mBanner = new Banner("a14dbba084368db");
+
+	int platformType = getPlatform();
+	if (platformType == ANDROID || platformType == IOS)
+	{
+		// ID required for the android platform (the IOS platform will ignore it)
+		mBanner = new Banner("a14dbba084368db");
+	}
+	else if (getPlatform() == WINDOWSPHONE7)
+	{
+		// we need to send the APP ID and the AD ID to the mosync banner constructor
+		// for the windows phone 7 platform (we'll use APP ID = 'test_client' and
+		// AD ID = 'Image480_80' to enable the test mode)
+		mBanner = new Banner("test_client|Image480_80");
+	}
+
 	mBanner->requestContent(true);
 	mainLayout->addBanner(mBanner);
 
@@ -207,7 +221,7 @@ void MainScreen::bannerFailedLoad(
 	itoa(error, buf, 10);
 	MAUtil::String text = "bannerFailedLoad error code = ";
 	text += buf;
-	mBannerMessage->setText("bannerFailedLoad");
+	mBannerMessage->setText(text);
 }
 
 /**

--- a/testPrograms/AdsTest/Util.h
+++ b/testPrograms/AdsTest/Util.h
@@ -26,39 +26,36 @@ MA 02110-1301, USA.
 #ifndef UTIL_H_
 #define UTIL_H_
 
-#include <maprofile.h>	// Profile database.
 #include <mastring.h>		// C string functions
 
-/**
- * Detects if the current platform is Android.
- * @return true if the platform is Android, false otherwise.
- */
-static bool isAndroid()
-{
-	if ( NULL != strstr(MA_PROF_STRING_PLATFORM, "android"))
-	{
-		return true;
-	}
-	else
-	{
-		return false;
-	}
-}
+#define BUF_MAX 256
+
+enum platform_code{
+	ANDROID = 0,
+	IOS = 1,
+	WINDOWSPHONE7 = 2
+};
 
 /**
- * Detects if the current platform is iOS.
- * @return true if the platform is iOS, false otherwise.
+ * Detects the current platform
+ * @return platform_code specific for Android, iPhone OS or WindowsPhone
  */
-static bool isIOS()
+static int getPlatform()
 {
-	if ( NULL != strstr(MA_PROF_STRING_PLATFORM, "iphoneos"))
+	char platform[BUF_MAX];
+	maGetSystemProperty("mosync.device.OS", platform, BUF_MAX);
+
+	if(strcmp(platform, "Android") == 0)
 	{
-		return true;
+		return ANDROID;
 	}
 	else
 	{
-		return false;
+		if(strcmp(platform, "iPhone OS") == 0)
+			return IOS;
 	}
+	return WINDOWSPHONE7;
 }
+
 
 #endif /* UTIL_H_ */


### PR DESCRIPTION
MOSYNC-2296: fixed the ads test program (added a new Banner constructor with the windows phone ads test ids and changed the platform checking function); fixed a crash on the windows phone platform

MOSYNC-2292: because there was no resources file inside the CameraDemo application, the mosync runtime didn't initialize the mCurrentResourceHandle to 1 so the maCreatePlaceholder returned 0 on the first try. The variable is now initialized inside the runtime constructor

WP 7 CameraModule: the camera format is now correctly set; added some comments; refactored some methods
