### PR TITLE
[MOSYNC-2323] Fixed the newlib key code 0 press crash by changing the pr...

### DIFF
--- a/templates/C Newlib Project/main.c
+++ b/templates/C Newlib Project/main.c
@@ -33,7 +33,7 @@ int MAMain()
 					break;
 				}
 
-				printf("You typed: %c\n", event.key);
+				printf("You typed key code: %d\n", event.key);
 			}
 		}
 	}


### PR DESCRIPTION
...int into keycode.
