### PR TITLE
MOSYNC-2162: resolved - the widget was not removed from the widget list ...

### DIFF
--- a/libs/NativeUI/Widget.cpp
+++ b/libs/NativeUI/Widget.cpp
@@ -409,8 +409,8 @@ namespace NativeUI
      * Remove a child widget from its parent (but does not destroy it).
      * Removing a currently visible top-level widget causes the MoSync view
      * to become visible.
-     * When the parent widget will be destroyed, the child widget will not
-     * be deleted.
+     * When the parent widget will be destroyed, the removed child widget will not
+     * be deleted (this responsibility is left to the developer).
      * @param widget The widget to be removed.
      * @return Any of the following result codes:
      * - #MAW_RES_OK if the child could be removed from the parent.

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncNativeUIModule.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncNativeUIModule.cs
@@ -62,7 +62,7 @@ namespace MoSync
 					return MoSync.Constants.MAW_RES_INVALID_HANDLE;
                 IWidget widget = mWidgets[_widget];
                 widget.RemoveFromParent();
-                mWidgets[_widget] = null;
+                mWidgets.RemoveAt(_widget);
                 return MoSync.Constants.MAW_RES_OK;
             };
 

--- a/testPrograms/native_ui_lib/WidgetTest/.mosyncproject
+++ b/testPrograms/native_ui_lib/WidgetTest/.mosyncproject
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project supports-build-configs="true" version="1.2">
+<project supports-build-configs="true" version="1.5">
 <build.cfg id="Debug" types="Debug"/>
 <build.cfg id="Release" types="Release"/>
+<criteria>
+<filter type="com.mobilesorcery.sdk.capabilities.devices.elementfactory">
+<capabilities optional="" required="File\ Storage Internet\ Access"/>
+</filter>
+</criteria>
 <properties>
 <property key="build.prefs:additional.include.paths/Debug" value=""/>
 <property key="build.prefs:additional.include.paths/Release" value=""/>
@@ -10,6 +15,7 @@
 <property key="build.prefs:additional.libraries/Release" value="MAUtil.lib,nativeui.lib"/>
 <property key="build.prefs:additional.library.paths/Debug" value=""/>
 <property key="build.prefs:additional.library.paths/Release" value=""/>
+<property key="build.prefs:app.permissions" value="File\ Storage Internet\ Access Vibration"/>
 <property key="build.prefs:extra.link.sw/Debug" value=""/>
 <property key="build.prefs:extra.link.sw/Release" value=""/>
 <property key="build.prefs:extra.res.sw/Debug" value=""/>
@@ -26,6 +32,8 @@
 <property key="dependency.strategy" value="0"/>
 <property key="excludes/Debug" value=""/>
 <property key="excludes/Release" value=""/>
+<property key="profile.mgr.type" value="0"/>
 <property key="template.id" value="project.nativeuicpp"/>
+<property key="winmobilecs:guid" value="6f42f050-cdc1-102f-80a6-1d9b1c32b28d"/>
 </properties>
 </project>


### PR DESCRIPTION
MOSYNC-2162: resolved - the widget was not removed from the widget list - only set to null; updated the '.mosyncproject' file of the native ui test program WidgetTest - it now uses the platform based profiles; Updated the 'removeChild' documentation
