### PR TITLE
MOSYNC-2361: fixed

### DIFF
--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncNativeUIModule.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncNativeUIModule.cs
@@ -61,8 +61,11 @@ namespace MoSync
 				if (_widget < 0 || _widget >= mWidgets.Count)
 					return MoSync.Constants.MAW_RES_INVALID_HANDLE;
                 IWidget widget = mWidgets[_widget];
-                widget.RemoveFromParent();
-                mWidgets.RemoveAt(_widget);
+                if (widget != null)
+                {
+                    widget.RemoveFromParent();
+                    mWidgets[_widget] = null;
+                }
                 return MoSync.Constants.MAW_RES_OK;
             };
 


### PR DESCRIPTION
commit dba9cd4b7baafd176156b4a58eef8ced4f00308c
Author: Spiridon Alexandru spiridon.g.alex@gmail.com
Date:   Tue Aug 28 19:39:25 2012 +0300

```
MOSYNC-2361: fixed - the problem was that in a previous fix, on a 'maWidgetDestroy' call I removed the destroyed item - this reordered all the widget list and created problems. The deleted widget is now only set to null
```
