### PR TITLE
[MOSYNC-2681] Keyboad not visible after viewing result details on WikiSearchNativeUI demo Android 2.3

### DIFF
--- a/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/internal/android/MoSyncNativeUI.java
+++ b/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/internal/android/MoSyncNativeUI.java
@@ -509,6 +509,7 @@ public class MoSyncNativeUI implements RootViewReplacedListener
 	@Override
 	public void rootViewReplaced(View newRoot)
 	{
+		newRoot.clearFocus();
 		((MoSync) getActivity()).setRootView( newRoot );
 	}
 

--- a/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/internal/android/MoSyncThread.java
+++ b/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/internal/android/MoSyncThread.java
@@ -1333,8 +1333,8 @@ public class MoSyncThread extends Thread
 
 			if(i >= count*2)
 				break;
-			xa = vertices[i++];
-			ya = vertices[i++];
+			xb = vertices[i++];
+			yb = vertices[i++];
 			path.moveTo(xa,ya);
 			path.lineTo(xc,yc);
 			path.lineTo(xb,yb);

--- a/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/nativeui/ui/factories/EditBoxFactory.java
+++ b/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/nativeui/ui/factories/EditBoxFactory.java
@@ -42,8 +42,6 @@ import com.mosync.nativeui.ui.widgets.Widget;
  */
 public class EditBoxFactory implements AbstractViewFactory
 {
-	boolean m_clearFocus = true;
-
 	@Override
 	public Widget create(Activity activity, final int handle)
 	{
@@ -80,15 +78,6 @@ public class EditBoxFactory implements AbstractViewFactory
 			public void onFocusChange(View v, boolean hasFocus) {
 				if (hasFocus)
 				{
-					if ( Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH )
-					{
-						//when the editbox is added to the screen it's gaining focus and trying to show the keyboard but it fails
-						if (m_clearFocus) {
-							m_clearFocus = false;
-							v.clearFocus();
-							return;
-						}
-					}
 					EventQueue.getDefault( ).postWidgetEvent(
 							IX_WIDGET.MAW_EVENT_EDIT_BOX_EDITING_DID_BEGIN, handle );
 				}

--- a/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/nativeui/ui/widgets/StackScreenWidget.java
+++ b/runtimes/java/platforms/androidJNI/AndroidProject/src/com/mosync/nativeui/ui/widgets/StackScreenWidget.java
@@ -93,6 +93,7 @@ public class StackScreenWidget extends ScreenWidget
 		m_screenStack.push( screen );
 		getView( ).removeAllViews( );
 		//getView( ).addView( screen.getView( ) );
+		screen.getRootView( ).clearFocus();
 		getView( ).addView( screen.getRootView( ) );
 	}
 
@@ -143,6 +144,7 @@ public class StackScreenWidget extends ScreenWidget
 		ScreenWidget previousScreen = m_screenStack.peek( );
 		if( previousScreen != null )
 		{
+			previousScreen.getView( ).clearFocus();
 			getView( ).addView( previousScreen.getView( ) );
 		}
 	}


### PR DESCRIPTION
[MOSYNC-2681] Keyboad not visible after viewing result details on WikiSearchNativeUI demo Android 2.3
