### PR TITLE
Fix for MOSYNC-2710 "MaUtil's Downloader Class crashes".

### DIFF
--- a/libs/MAUtil/Downloader.h
+++ b/libs/MAUtil/Downloader.h
@@ -190,8 +190,10 @@ namespace MAUtil {
 		/**
 		 * Function to cancel the current download.
 		 * Do cleanup and send downloadCancelled to listeners.
+		 * \return \>0 on success, or \link #CONNERR_NO_ACTIVE_DOWNLOAD CONNERR \endlink
+		 * code if there is no active download.
 		 */
-		virtual void cancelDownloading();
+		virtual int cancelDownloading();
 
 		/**
 		 * Function to retrieve if the Downloader is currently

--- a/runtimes/cpp/platforms/iphone/Classes/NativeUI/Layouts/LayoutWidgets.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/NativeUI/Layouts/LayoutWidgets.mm
@@ -68,7 +68,7 @@
 }
 
 - (int) getTopMargin{
-	return topMargin;;
+	return topMargin;
 }
 
 - (int) getBottomMargin {

--- a/runtimes/cpp/platforms/iphone/Classes/NativeUI/Layouts/VerticalLayoutWidget.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/NativeUI/Layouts/VerticalLayoutWidget.mm
@@ -94,8 +94,9 @@
  */
 - (CGSize)sizeThatFitsForWidget
 {
+    AbstractLayoutView* alv = (AbstractLayoutView*)self.view;
     float maxWidth = 0.0;
-    float countHeight = 0.0;
+    float countHeight = ([alv getTopMargin] + [alv getBottomMargin]);
     for (IWidget* child in _children)
     {
         countHeight += child.height;

--- a/tools/idl2/maapi.idl
+++ b/tools/idl2/maapi.idl
@@ -697,7 +697,12 @@ interface MAAPI {
 		NOTFOUND = -17;
 		/// An error occurred during SSL negotiation.
 		SSL = -18;
-
+		/// A download is already in progress.
+		DOWNLOAD_IN_PROGRESS = -19;
+		/// There is no active download.
+		NO_ACTIVE_DOWNLOAD = -20;
+		// Downloader has no available reader. This happens after the connection is closed.
+		READER_UNAVAILABLE = -21;
 		/**
 		* If you wish to share the CONNERR codespace,
 		* use values below this for your own error codes.


### PR DESCRIPTION
Fix for "MaUtil's Downloader Class crashes when it is used multiple times in a quick way." issue. http://jira.mosync.com/browse/MOSYNC-2710
