### PR TITLE
Fix for MOSYNC-2726. wrapContentHorizontally excedes the screen.

### DIFF
--- a/runtimes/cpp/platforms/iphone/Classes/NativeUI/Layouts/HorizontalLayoutWidget.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/NativeUI/Layouts/HorizontalLayoutWidget.mm
@@ -66,11 +66,19 @@
             case WidgetAutoSizeWrapContent:
                 viewWidth = [child sizeThatFitsForWidget].width;
                 countWidth += viewWidth;
+
+                // If width of the children excedes the available width force the child to fill the available space.
+                if ( countWidth > (self.width - totalHorizontalMargin) )
+                {
+                    countWidth -= viewWidth;
+                    [fillParentWidgets addObject:child];
+                }
                 break;
             case WidgetAutoSizeFixed:
                 countWidth += viewWidth;
                 break;
         }
+
         child.size = CGSizeMake(viewWidth, viewHeight);
     }
 
@@ -95,13 +103,16 @@
  */
 - (CGSize)sizeThatFitsForWidget
 {
-    float countWidth = 0.0;
+    AbstractLayoutView* alv = (AbstractLayoutView*)self.view;
+    float countWidth = ([alv getLeftMargin] + [alv getRightMargin]); //Add horizontal padding.
     float maxHeight = 0.0;
+
     for (IWidget* child in _children)
     {
         countWidth += child.width;
         maxHeight = MAX(maxHeight, child.height);
     }
+    maxHeight += ([alv getTopMargin] + [alv getBottomMargin]); //Add vertical padding.
     return CGSizeMake(countWidth, maxHeight);
 }
 

--- a/runtimes/cpp/platforms/iphone/Classes/NativeUI/Layouts/VerticalLayoutWidget.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/NativeUI/Layouts/VerticalLayoutWidget.mm
@@ -54,6 +54,13 @@
             self.parent)
         {
             viewWidth = [child sizeThatFitsForWidget].width;
+
+            // Force child to have smaller/equal width with its parrent in the context of vertical layout.
+            int maxViewWidth = self.width - totalHorizontalMargin;
+            if ( viewWidth > maxViewWidth )
+            {
+                viewWidth = maxViewWidth;
+            }
         }
 
         switch (child.autoSizeHeight)


### PR DESCRIPTION
Fix for http://jira.mosync.com/browse/MOSYNC-2726
