### PR TITLE
MOSYNC-2707: fixed - the wp7 list view item widget calls its base class ...

### DIFF
--- a/runtimes/csharp/windowsphone/mosync/mosync/App.xaml
+++ b/runtimes/csharp/windowsphone/mosync/mosync/App.xaml
@@ -38,7 +38,7 @@
         <!-- The list item template of a LongListSelector -->
         <DataTemplate x:Key="listItemTemplate">
             <Border BorderThickness="2">
-                <Grid Height="{Binding Height}" Width="{Binding Width}">
+                <Grid Height="{Binding Height}" Width="{Binding Width}" HorizontalAlignment="Left">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"></ColumnDefinition>
                         <ColumnDefinition></ColumnDefinition>

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/ListView/ListViewWidgets/MoSyncListViewItem.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/ListView/ListViewWidgets/MoSyncListViewItem.cs
@@ -234,7 +234,14 @@ namespace MoSync
                 }
                 set
                 {
-                    mGrid.Width = value;
+                    if (value > 0)
+                    {
+                        mGrid.Width = value;
+                    }
+                    else
+                    {
+                        base.Width = value;
+                    }
                 }
             }
 

--- a/testPrograms/native_ui_lib/SegmentedListTest/ListScreen.cpp
+++ b/testPrograms/native_ui_lib/SegmentedListTest/ListScreen.cpp
@@ -103,6 +103,7 @@ void ListScreen::createMainLayout() {
 			itemText += MAUtil::integerToString(j);
 			item->setText(itemText);
 			item->setSubtitle("subtitle " + MAUtil::integerToString(j));
+			item->fillSpaceHorizontally();
 			section->addItem(item);
 		}
 


### PR DESCRIPTION
...when 'fillSpaceHorizontally' gets called + small change inside the list item template + the 'SegmentedListTes' now calls 'fillSpaceHorizontally' for every list view item
