### PR TITLE
Solved MOSYNC-2818 and MOSYNC-2829

### DIFF
--- a/runtimes/csharp/windowsphone/mosync/mosync/App.xaml.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosync/App.xaml.cs
@@ -47,7 +47,7 @@ namespace test_mosync
         /// </summary>
         public App()
         {
-            // Global handler for uncaught exceptions. 
+            // Global handler for uncaught exceptions.
             UnhandledException += Application_UnhandledException;
 
             // Standard Silverlight initialization
@@ -68,7 +68,7 @@ namespace test_mosync
                 // Show the areas of the app that are being redrawn in each frame.
                 //Application.Current.Host.Settings.EnableRedrawRegions = true;
 
-                // Enable non-production analysis visualization mode, 
+                // Enable non-production analysis visualization mode,
                 // which shows areas of a page that are handed off to GPU with a colored overlay.
                 //Application.Current.Host.Settings.EnableCacheVisualization = true;
 
@@ -78,7 +78,7 @@ namespace test_mosync
                 // and consume battery power when the user is not using the phone.
                 PhoneApplicationService.Current.UserIdleDetectionMode = IdleDetectionMode.Disabled;
             }
-        }
+       }
 
         // Code to execute when the application is launching (eg, from Start)
         // This code will not execute when the application is reactivated
@@ -139,6 +139,8 @@ namespace test_mosync
 					machine.Run();
 				}
             };
+
+            RootFrame.BackKeyPress += new EventHandler<System.ComponentModel.CancelEventArgs>(BackKeyPressHandler);
         }
 
         // Code to execute when the application is activated (brought to foreground)
@@ -209,7 +211,7 @@ namespace test_mosync
 
             // Ensure we don't initialize again
             phoneApplicationInitialized = true;
-        }
+       }
 
         // Do not add any additional code to this method
         private void CompleteInitializePhoneApplication(object sender, NavigationEventArgs e)
@@ -217,7 +219,7 @@ namespace test_mosync
             // Set the root visual to allow the application to render
             if (RootVisual != RootFrame)
                 RootVisual = RootFrame;
-      
+
             // Remove this handler since it is no longer needed
             RootFrame.Navigated -= CompleteInitializePhoneApplication;
         }
@@ -257,5 +259,28 @@ namespace test_mosync
         }
 
         #endregion
+
+        /**
+        * The BackKeyPress event handler.
+        * Currently it contains the functionality for the back event when a StackScreen is a child of a TabScreen.
+        * When this handler does not cover the functionality required it should be updated.
+        * @param from Object the object that triggers the event.
+        * @param args System.ComponentModel.CancelEventArgs the event arguments.
+        */
+        public void BackKeyPressHandler(object from, System.ComponentModel.CancelEventArgs args)
+        {
+            NativeUIModule nativeUIModule = machine.GetRuntime().GetModule<NativeUIModule>();
+
+            //EVENT_TYPE_KEY_RELEASED event data
+            Memory eventData = new Memory(8);
+            const int MAEventData_eventType = 0;
+            const int MAEventData_backButtonKeyCode = 4;
+            eventData.WriteInt32(MAEventData_eventType, MoSync.Constants.EVENT_TYPE_KEY_PRESSED);
+            eventData.WriteInt32(MAEventData_backButtonKeyCode, MoSync.Constants.MAK_BACK);
+            //Posting a CustomEvent
+            machine.GetRuntime().PostEvent(new Event(eventData));
+
+            args.Cancel = nativeUIModule.HandleBackButtonPressed();
+        }
     }
 }

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncGraphicsModule.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncGraphicsModule.cs
@@ -313,7 +313,22 @@ namespace MoSync
 
 			syscalls.maGetScrSize = delegate()
 			{
-				return MoSync.Util.CreateExtent(mBackBuffer.PixelWidth, mBackBuffer.PixelHeight);
+                int w = mBackBuffer.PixelWidth;
+                int h = mBackBuffer.PixelHeight;
+                MoSync.Util.RunActionOnMainThreadSync(() =>
+                {
+                    // if the orientation is landscape, the with and height should be swaped
+                    PhoneApplicationPage currentPage = (((PhoneApplicationFrame)Application.Current.RootVisual).Content as PhoneApplicationPage);
+                    if (currentPage.Orientation == PageOrientation.Landscape ||
+                        currentPage.Orientation == PageOrientation.LandscapeLeft ||
+                        currentPage.Orientation == PageOrientation.LandscapeRight)
+                    {
+                        int aux = w;
+                        w = h;
+                        h = w;
+                    }
+                });
+				return MoSync.Util.CreateExtent(w, h);
 			};
 
 			syscalls.maGetImageSize = delegate(int handle)

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncNativeUIModule.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/MoSyncNativeUIModule.cs
@@ -7,6 +7,10 @@ namespace MoSync
     public class NativeUIModule : IIoctlModule
     {
         private UIManager mNativeUI;
+        /**
+         * A reference to the last shown screen.
+         */
+        private IScreen mCurrentScreen = null;
         private List<IWidget> mWidgets = new List<IWidget>();
 
 		public IWidget GetWidget(int handle)
@@ -16,6 +20,19 @@ namespace MoSync
 			IWidget w = mWidgets[handle];
 			return w;
 		}
+
+        /**
+         * Handles the back button pressed event.
+         * @return true if the event has been consumed, false otherwise.
+         */
+        public bool HandleBackButtonPressed()
+        {
+            if (mCurrentScreen != null)
+            {
+                return mCurrentScreen.HandleBackButtonPressed();
+            }
+            return true;
+        }
 
         /*
          * Ads a widget to the widgets array.
@@ -169,6 +186,7 @@ namespace MoSync
 				if (_screenHandle < 0 || _screenHandle >= mWidgets.Count)
 					return MoSync.Constants.MAW_RES_INVALID_HANDLE;
                 IScreen screen = (IScreen)mWidgets[_screenHandle];
+                mCurrentScreen = screen;
                 screen.Show();
                 return MoSync.Constants.MAW_RES_OK;
             };

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncNativeUI.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncNativeUI.cs
@@ -32,6 +32,7 @@ namespace MoSync
             bool GetApplicationBarVisibility();
             void SetApplicationBarVisibility(bool value);
             int AddApplicationBarItemIndex(Object item);
+            bool HandleBackButtonPressed();
         }
 
         public class MoSyncWidgetPropertyAttribute : Attribute

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncScreen.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncScreen.cs
@@ -85,67 +85,18 @@ namespace MoSync
                 mApplicationBarItemsIndexes = new Dictionary<Object, int>();
 
                 /**
-                 * This will add a BackKeyPress event handler to the Application.Current.RootVisual, this is application wide.
-                 */
-                (Application.Current.RootVisual as Microsoft.Phone.Controls.PhoneApplicationFrame).BackKeyPress += new EventHandler<System.ComponentModel.CancelEventArgs>(BackKeyPressHandler);
-                /**
-                 * This will add a BackKeyPress event handler to the Application.Current.RootVisual, this is application wide.
+                 * This will add a OrientationChanged event handler to the Application.Current.RootVisual, this is application wide.
                  */
                 (Application.Current.RootVisual as Microsoft.Phone.Controls.PhoneApplicationFrame).OrientationChanged += new EventHandler<Microsoft.Phone.Controls.OrientationChangedEventArgs>(OrientationChangedHandler);
             }
 
             /**
-             * The BackKeyPress event handler.
-             * Currently it contains the functionality for the back event when a StackScreen is a child of a TabScreen.
-             * When this handler does not cover the functionality required it should be updated.
-             * @param from Object the object that triggers the event.
-             * @param args System.ComponentModel.CancelEventArgs the event arguments.
+             * Handles the back button pressed event.
+             * @return true if the event has been consumed, false otherwise.
              */
-            public void BackKeyPressHandler(object from, System.ComponentModel.CancelEventArgs args)
+            public virtual bool HandleBackButtonPressed()
             {
-                //Will check if the event is not canceled.
-                if (false == args.Cancel)
-                {
-                    //If the caller screen is a TabScreen, otherwise pass the event to the parent.
-                    if (this is TabScreen)
-                    {
-                        Microsoft.Phone.Controls.Pivot pivot = ((this as TabScreen).mPivot);
-                        //If the selected tab is a StackScreen.
-                        if (this.mChildren[pivot.SelectedIndex] is StackScreen)
-                        {
-                            //If pop is possible.
-                            if ((this.mChildren[pivot.SelectedIndex] as StackScreen).StackCount() > 1 && (this.mChildren[pivot.SelectedIndex] as StackScreen).GetBackButtonEnabled() == true)
-                            {
-                                //Do a pop and cancel the event.
-                                (this.mChildren[pivot.SelectedIndex] as StackScreen).PopFromBackButtonPressed();
-                                args.Cancel = true;
-                            }
-                        }
-                        //If the selected tab is not a StackScreen the application should exit.
-                        else
-                        {
-                            //Remove the event handler from the TabScreen.
-                            (Application.Current.RootVisual as Microsoft.Phone.Controls.PhoneApplicationFrame).BackKeyPress -= BackKeyPressHandler;
-                        }
-                    }
-                    else if(this is StackScreen && !(this.GetParent() is TabScreen))
-                    {
-                        if (this.GetParent() is PanoramaView)
-                        {
-                            if ((this.GetParent() as PanoramaView).getSelectedScreen().Equals(this) && (this as StackScreen).StackCount() > 1)
-                            {
-                                (this as StackScreen).PopFromBackButtonPressed();
-                                args.Cancel = true;
-                            }
-                        }
-                        else if((this as StackScreen).StackCount() > 1 && (this as StackScreen).GetBackButtonEnabled() == true)
-                        {
-                            //Do a pop and cancel the event.
-                            (this as StackScreen).PopFromBackButtonPressed();
-                            args.Cancel = true;
-                        }
-                    }
-                }
+                return false;
             }
 
             /**

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncStackScreen.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncStackScreen.cs
@@ -52,7 +52,7 @@ namespace MoSync
             {
                 mStack = new System.Collections.Generic.Stack<IScreen>();
                 mApplicationBarItemsIndexes = new Dictionary<Object, int>();
-            }
+           }
 
             /**
              * Override the AddChild function
@@ -233,6 +233,33 @@ namespace MoSync
                         Microsoft.Phone.Controls.PhoneApplicationPage).ApplicationBar.IsVisible = false;
                     }
                 }
+            }
+
+            /**
+             * Handles the back button pressed event.
+             * @return true if the event has been consumed, false otherwise.
+             */
+            public override bool HandleBackButtonPressed()
+            {
+                if (!(this.GetParent() is TabScreen))
+                {
+                    if (this.GetParent() is PanoramaView)
+                    {
+                        if ((this.GetParent() as PanoramaView).getSelectedScreen().Equals(this) && (this as StackScreen).StackCount() > 1)
+                        {
+                            (this as StackScreen).PopFromBackButtonPressed();
+                            return true;
+                        }
+                    }
+                    else if ((this as StackScreen).StackCount() > 1 && (this as StackScreen).GetBackButtonEnabled() == true)
+                    {
+                        //Do a pop and cancel the event.
+                        (this as StackScreen).PopFromBackButtonPressed();
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
     }

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncTabScreen.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncTabScreen.cs
@@ -190,6 +190,28 @@ namespace MoSync
                     return mPivot.SelectedIndex;
                 }
             }
+
+            /**
+             * Handles the back button pressed event.
+             * @return true if the event has been consumed, false otherwise.
+             */
+            public override bool HandleBackButtonPressed()
+            {
+                Microsoft.Phone.Controls.Pivot pivot = this.mPivot;
+                //If the selected tab is a StackScreen.
+                if (this.mChildren[pivot.SelectedIndex] is StackScreen)
+                {
+                    //If pop is possible.
+                    if ((this.mChildren[pivot.SelectedIndex] as StackScreen).StackCount() > 1 && (this.mChildren[pivot.SelectedIndex] as StackScreen).GetBackButtonEnabled() == true)
+                    {
+                        //Do a pop and cancel the event.
+                        (this.mChildren[pivot.SelectedIndex] as StackScreen).PopFromBackButtonPressed();
+                        return true;
+                    }
+                }
+
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
MOSYNC-2818: The back button is handled inside the screen class - it should be handled separately by every screen type (TabScreen, StackScreen and Screen).
Also, an event needs to be sent to mosync when the back button is touched.

MOSYNC-2829: On wp7 platform 'maGetScrSize()' returns the same values disregarding the screen orientation.
