### PR TITLE
Three two one

### DIFF
--- a/examples/cpp/SensorTest/consts.h
+++ b/examples/cpp/SensorTest/consts.h
@@ -37,7 +37,7 @@ MA 02110-1301, USA.
 #define SCALE_FACTOR 					(gScreenWidth / BASE_SCREEN_WIDTH)
 #define TEXT_SIZE						(10 * SCALE_FACTOR)
 #define OFFSET_X						(10 * SCALE_FACTOR)
-#define OFFSET_Y						20
+#define OFFSET_Y						TEXT_SIZE
 
 // useful texts
 #define TXT_NONE						""

--- a/libs/Notification/LocalNotification.cpp
+++ b/libs/Notification/LocalNotification.cpp
@@ -540,6 +540,8 @@ namespace Notification
 
     /**
      * Set the date and time when the system should deliver the notification.
+	 * The notification will be fired when the system time is equal to the
+	 * given param time value.
      * @param tm A date and time struct that specifies when the system
      * should deliver the notification.
      * @return Any of the following result codes:

--- a/libs/Notification/LocalNotification.h
+++ b/libs/Notification/LocalNotification.h
@@ -491,6 +491,8 @@ namespace Notification
 
         /**
          * Set the date and time when the system should deliver the notification.
+		 * The notification will be fired when the system time is equal to the
+		 * given param time value.
          * @param time A date and time struct that specifies when the system
          * should deliver the notification.
          * @return Any of the following result codes:

--- a/runtimes/cpp/platforms/iphone/Classes/MoSyncView.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/MoSyncView.mm
@@ -199,13 +199,27 @@ Software Foundation, 59 Temple Place - Suite 330, Boston, MA
 }
 -(void) messageBox:(id) obj {
 	MessageBoxHandler *mbh = (MessageBoxHandler*) obj;
-	UIAlertView *alert = [[UIAlertView alloc] 
+	UIAlertView *alert = [[UIAlertView alloc]
                           initWithTitle:mbh.title
                           message:mbh.msg
                           delegate:mbh
                           cancelButtonTitle:mbh.cancelTitle
-                          otherButtonTitles:mbh.button1Title, mbh.button2Title, mbh.button3Title, nil];
-	
+                          otherButtonTitles:nil];
+
+	// Add only valid strings as buttons.
+	if (mbh.button1Title)
+	{
+		[alert addButtonWithTitle:mbh.button1Title];
+	}
+	if (mbh.button2Title)
+	{
+		[alert addButtonWithTitle:mbh.button2Title];
+	}
+	if (mbh.button3Title)
+	{
+		[alert addButtonWithTitle:mbh.button3Title];
+	}
+
 	[touchHelper clearTouches];
 	if (mbh.cancelTitle == nil) {
 		alert.cancelButtonIndex = -1;
@@ -215,7 +229,7 @@ Software Foundation, 59 Temple Place - Suite 330, Boston, MA
 }
  
 -(void) showMessageBox: (NSString*)msg withTitle: (NSString*)title shouldKill: (bool)kill {
-	MessageBoxHandler *mbh = [[MessageBoxHandler alloc] retain];
+	MessageBoxHandler *mbh = [[[MessageBoxHandler alloc] init] autorelease];
 	mbh.kill = kill;
 	mbh.title = title;
 	mbh.msg = msg;

--- a/runtimes/cpp/platforms/iphone/Classes/NativeUI/WidgetUtils/WidgetUtils.h
+++ b/runtimes/cpp/platforms/iphone/Classes/NativeUI/WidgetUtils/WidgetUtils.h
@@ -34,6 +34,9 @@
 return  MAW_RES_INVALID_PROPERTY_VALUE; \
 }
 
+// Used for converting milliseconds in seconds.
+#define SECOND 1000.0
+
 /**
  * Enums for widget size. Since iOS views are using only fixed sizes, the wrap and fill properties
  * are custom.

--- a/runtimes/cpp/platforms/iphone/Classes/NativeUI/Widgets/ButtonWidget.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/NativeUI/Widgets/ButtonWidget.mm
@@ -113,6 +113,7 @@
 		Surface* imageResource = Base::gSyscall->resources.get_RT_IMAGE(imageHandle);
 		image = [UIImage imageWithCGImage:imageResource->image];
 		[button setBackgroundImage:image forState:UIControlStateNormal];
+		[self layout];
 	}
     else
     if([key isEqualToString:@MAW_IMAGE_BUTTON_IMAGE]) {
@@ -122,6 +123,7 @@
         Surface* imageResource = Base::gSyscall->resources.get_RT_IMAGE(imageHandle);
         image = [UIImage imageWithCGImage:imageResource->image];
         [button setImage:image forState:UIControlStateNormal];
+		[self layout];
     }
 	else if([key isEqualToString:@"leftCapWidth"]) {
 		int newLeftCapWidth = [value intValue];

--- a/runtimes/cpp/platforms/iphone/Classes/NativeUI/Widgets/ListViewItemWidget.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/NativeUI/Widgets/ListViewItemWidget.mm
@@ -248,7 +248,7 @@ static NSString* kReuseIdentifier = @"Cell";
  */
 - (int)addChild:(IWidget*)child
 {
-    if (_children.count ==0 )
+    if (_children.count == 0 )
     {
         [super addChild:child toSubview:YES];
     }
@@ -437,6 +437,11 @@ static NSString* kReuseIdentifier = @"Cell";
     {
         IWidget* child = [_children objectAtIndex:0];
         size = child.size;
+		if (child.autoSizeWidth == WidgetAutoSizeFillParent)
+		{
+			size.width = self.width;
+			child.width = self.width;
+		}
     }
     else if (self.autoSizeHeight != WidgetAutoSizeFixed)
     {

--- a/runtimes/cpp/platforms/iphone/Classes/NativeUI/Widgets/VideoViewWidget.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/NativeUI/Widgets/VideoViewWidget.mm
@@ -104,7 +104,9 @@
     else if ([key isEqualToString:@MAW_VIDEO_VIEW_SEEK_TO])
     {
         TEST_FOR_NEGATIVE_VALUE([value floatValue]);
-        [_moviePlayerController setCurrentPlaybackTime:[value floatValue]];
+		// Value is in milliseconds we we have to convert it to seconds.
+		CGFloat timeInSeconds = [value floatValue] / SECOND;
+        [_moviePlayerController setCurrentPlaybackTime: timeInSeconds];
     }
     else if ([key isEqualToString:@MAW_VIDEO_VIEW_CONTROL])
     {

--- a/runtimes/cpp/platforms/iphone/Classes/notifications/NotificationManager.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/notifications/NotificationManager.mm
@@ -198,10 +198,7 @@ static NotificationManager *sharedInstance = nil;
         }
 
         // Notification fire date must be in GMT + 0:00 format(system time).
-        // Received date is using local time.
         double seconds = [value doubleValue];
-        NSTimeZone* localTimeZone = [NSTimeZone localTimeZone];
-        seconds -= [localTimeZone secondsFromGMT];
         NSDate* date = [NSDate dateWithTimeIntervalSince1970:seconds];
         notification.fireDate = date;
     }

--- a/tools/idl2/maapi.idl
+++ b/tools/idl2/maapi.idl
@@ -5900,9 +5900,12 @@ group NotificationAPI "Notification API" {
 
 			/**
 			* @brief Set the date and time when the system should deliver the notification.
+			* The notification will be fired when the system time is equal to the
+			* given param time value.
 			*
 			* @validvalue an int.
 			* The date is in seconds(UNIX time - seconds elapsed since January 1, 1970).
+			* The value should be given according to device system time.
 			*
 			* @setandget
 			*


### PR DESCRIPTION
Contains fixes for:
MOSYNC-2902 Sensor test is scrambled on ipad
MOSYNC-2880 Slider doesn't FF the video on IOS
MOSYNC-2896 Send button not visible for LocalNotificationSender app on iOS
MOSYNC-2905 OK button from maAlert dialog not shown in LocalNotificationSender
MOSYNC-2906 Fire date not working in LocalNotificationSender
MOSYNC-2907 Too small width for EditBox widgets in LocalNotificationSender
