### PR TITLE
MOSYNC-3128

### DIFF
--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncScreen.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncScreen.cs
@@ -293,7 +293,19 @@ namespace MoSync
             {
                 set
                 {
-                   mTitle = value;
+                    mTitle = value;
+                    IWidget parent = GetParent();
+                    // if the parent widget is a TabScreen, we need to update the screen
+                    // title if the property has been set after the current screen has been
+                    // added as a pivot element
+                    if (parent is TabScreen)
+                    {
+                        (parent as TabScreen).UpdateScreenTitle(this);
+                    }
+                }
+                get
+                {
+                    return mTitle;
                 }
             }
 

--- a/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncTabScreen.cs
+++ b/runtimes/csharp/windowsphone/mosync/mosyncRuntime/Source/Modules/NativeUI/MoSyncTabScreen.cs
@@ -148,6 +148,40 @@ namespace MoSync
             }
 
             /**
+             * Searches for a screen inside the children array, gets the proper pivot item
+             * for that screen and then updates its header based on the child screen title.
+             * @param childScreen The child screen that needs a title update.
+             */
+            public void UpdateScreenTitle(Screen childScreen)
+            {
+                // the index of the current screen inside the pivot control
+                int index = -1;
+                bool foundScreen = false;
+
+                for (int i = 0; i < mChildren.Count; i++)
+                {
+                    // if a screen is inside the children array, it means it's a
+                    // visible pivot item so we can increment the pivot item index
+                    if (mChildren[i] is Screen)
+                    {
+                        index++;
+                        if (mChildren[i].Equals(childScreen))
+                        {
+                            // we found the child screen
+                            foundScreen = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (foundScreen && mPivot.Items[index] is Microsoft.Phone.Controls.PivotItem)
+                {
+                    Microsoft.Phone.Controls.PivotItem item = mPivot.Items[index] as Microsoft.Phone.Controls.PivotItem;
+                    item.Header = childScreen.Title;
+                }
+            }
+
+            /**
              * MAW_TAB_SCREEN_TITLE property implementation
              * In order to avoid the property hiding from Screen you have to specify
              * the new keyword in front of the property

--- a/testPrograms/native_ui_lib/TabScreenTest/.mosyncproject
+++ b/testPrograms/native_ui_lib/TabScreenTest/.mosyncproject
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project supports-build-configs="true" version="1.4">
+<project supports-build-configs="true" version="1.5">
 <build.cfg id="Debug" types="Debug"/>
 <build.cfg id="Release" types="Release"/>
 <criteria>

--- a/testPrograms/native_ui_lib/TabScreenTest/MainScreen.cpp
+++ b/testPrograms/native_ui_lib/TabScreenTest/MainScreen.cpp
@@ -42,9 +42,11 @@ MainScreen::MainScreen() :
     this->addTab(firstScreen);
 
     Screen* secondScreen = new Screen();
-    secondScreen->setTitle("2nd screen");
     addMainLayout(secondScreen, 0x123456);
     this->addTab(secondScreen);
+    // we set the title after the screen has been added as a
+    // tab screen child to check if the property is being set right
+    secondScreen->setTitle("2nd screen");
 
     this->addTabScreenListener(this);
     this->setActiveTab(1);


### PR DESCRIPTION
Info:
setting the title of a screen after it has been added as a tab screen child now looks if the parent is a tab screen and if so, searches for the screen and updates its title; I modified the TabScreenTest program: the second screen title is now set after the screen has been added to the tab screen

Fix:
commit bf056c2ab4b86db55c86a5306f3f22122175c146
Author: Spiridon Alexandru spiridon.g.alex@gmail.com
Date: Tue Apr 23 16:39:30 2013 +0300
Branch: master
MOSYNC-3128: setting the title of a screen after it has been added as a tab screen child now looks if the parent is a tab screen and if so, searches for the screen and updates its title; I modified the TabScreenTest program: the second screen title is now set after the screen has been added to the tab screen

Code review done by:
Ovidiu Chira
