### PR TITLE
fix for MOSYNC-3198 (sqlite issue on iOS)

### DIFF
--- a/runtimes/cpp/platforms/iphone/Classes/impl/SyscallImpl.mm
+++ b/runtimes/cpp/platforms/iphone/Classes/impl/SyscallImpl.mm
@@ -342,6 +342,7 @@ namespace Base {
 		maIOCtl_case(maDBOpen);
 		maIOCtl_case(maDBClose);
 		maIOCtl_case(maDBExecSQL);
+		maIOCtl_case(maDBExecSQLParams);
 		maIOCtl_case(maDBCursorDestroy);
 		maIOCtl_case(maDBCursorNext);
 		maIOCtl_case(maDBCursorGetColumnData);


### PR DESCRIPTION
- added maIOCtl_case(maDBExecSQLParams); to the SyscallImpl
