### PR TITLE
compile error in WidgetUtil.h - NULL is not a keyword in c/c++

### DIFF
--- a/libs/NativeUI/WidgetUtil.h
+++ b/libs/NativeUI/WidgetUtil.h
@@ -58,7 +58,7 @@ namespace NativeUI
         MAUtil::Vector<Listener*>& vector,
         Listener* listener)
 	{
-		if (listener == NULL)
+		if (!listener)
 		{
 			return;
 		}
@@ -85,7 +85,7 @@ namespace NativeUI
         MAUtil::Vector<Listener*>& vector,
         Listener* listener)
     {
-		if (listener == NULL)
+		if (!listener)
 		{
 			return;
 		}


### PR DESCRIPTION
- until now the error stayed hidden by other includes (ma.h)
