### PR TITLE
Update Facebook.cpp

### DIFF
--- a/libs/Facebook/HTTP/Facebook.cpp
+++ b/libs/Facebook/HTTP/Facebook.cpp
@@ -72,7 +72,7 @@ Facebook::Facebook(const String& appId, const MAUtil::Set<MAUtil::String>& permi
 //	mOAuthUrl += "display=touch&";
 //	mOAuthUrl += "client_id=" + mAppId;
 
-	mOAuthUrl = "https://www.facebook.com/dialog/oauth?";
+	mOAuthUrl = "https://m.facebook.com/dialog/oauth?";
 	mOAuthUrl += "redirect_uri=fbconnect%3A%2F%2Fsuccess&";
 	mOAuthUrl += "response_type=token&";
 	mOAuthUrl += "display=touch&";


### PR DESCRIPTION
Hi , on some devices , www.facebook.com makes problem and it is better  to use m.facebook.com . this way , it will work better.
